### PR TITLE
修复isRewritePageTitle=false时navigation中标题前出现null的bug

### DIFF
--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -196,17 +196,17 @@ function handlerAnchorsNavbar($, option, tocs, section) {
     }
     for (var i = 0; i < tocs.length; i++) {
         var h1Toc = tocs[i];
-        html += "<li><span class='title-icon " + tocLevel1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + h1Toc.level + "</b>" + h1Toc.name + "</a></li>";
+        html += "<li><span class='title-icon " + tocLevel1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + (h1Toc.level || "") + "</b>" + h1Toc.name + "</a></li>";
         if (h1Toc.children.length > 0) {
             html += "<ul>"
             for (var j = 0; j < h1Toc.children.length; j++) {
                 var h2Toc = h1Toc.children[j];
-                html += "<li><span class='title-icon " + tocLevel2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + h2Toc.level + "</b>" + h2Toc.name + "</a></li>";
+                html += "<li><span class='title-icon " + tocLevel2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + (h2Toc.level || "") + "</b>" + h2Toc.name + "</a></li>";
                 if (h2Toc.children.length > 0) {
                     html += "<ul>";
                     for (var k = 0; k < h2Toc.children.length; k++) {
                         var h3Toc = h2Toc.children[k];
-                        html += "<li><span class='title-icon " + tocLevel3Icon + "'></span><a href='#" + h3Toc.url + "'><b>" + h3Toc.level + "</b>" + h3Toc.name + "</a></li>";
+                        html += "<li><span class='title-icon " + tocLevel3Icon + "'></span><a href='#" + h3Toc.url + "'><b>" + (h3Toc.level || "") + "</b>" + h3Toc.name + "</a></li>";
                     }
                     html += "</ul>";
                 }


### PR DESCRIPTION
修复前：
```
null登录
null获取实例
```

修复后：
```
登录
获取实例
```