### PR TITLE
修复因同一页面 H[1-3] 标签名称一样导致锚点链接一样，使锚链接定位失败的bug

### DIFF
--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -96,7 +96,7 @@ function handlerH1Toc(option, count, header, tocs) {
     count.h1 = count.h1 + 1;
     count.h2 = 0;
     count.h3 = 0;
-    id = count.h1 + '-' + id;
+    id = count.h1 + '_' + id;
     if (option.isRewritePageTitle) {
         level = count.h1 + ". ";
         rewrite = level + title;
@@ -128,7 +128,7 @@ function handlerH2Toc(option, count, header, tocs) {
     var h1Toc = tocs[h1Index];
     count.h2 = count.h2 + 1;
     count.h3 = 0;
-    id = (count.h1 + '-' + count.h2 + "-") + id;
+    id = (count.h1 + '-' + count.h2 + "_") + id;
     if (option.isRewritePageTitle) {
         level = (count.h1 + '.' + count.h2 + ". ");
         rewrite = level + title;
@@ -165,7 +165,7 @@ function handlerH3Toc(option, count, header, tocs) {
     }
     var h2Toc = h1Toc.children[h2Tocs.length - 1];
     count.h3 = count.h3 + 1;
-    id = (count.h1 + "-" + count.h2 + "-" + count.h3 + "-") + id;
+    id = (count.h1 + "-" + count.h2 + "-" + count.h3 + "_") + id;
     if (option.isRewritePageTitle) {
         level = (count.h1 + "." + count.h2 + "." + count.h3 + ". ");
         rewrite = level + title;

--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -75,6 +75,7 @@ function handlerTocs($, option, section) {
  */
 function handlerTitle(option, header, id, title) {
     header.text(title);
+    header.attr('id', id);
     header.prepend('<a name="' + id + '" class="anchor-navigation-ex-anchor" '
         + 'href="#' + id + '">'
         + '<i class="fa fa-link" aria-hidden="true"></i>'
@@ -92,10 +93,11 @@ function handlerH1Toc(option, count, header, tocs) {
     var id = header.attr('id');
     var level = null; //层级
     var rewrite = title; // 重写以后的标题
+    count.h1 = count.h1 + 1;
+    count.h2 = 0;
+    count.h3 = 0;
+    id = count.h1 + '-' + id;
     if (option.isRewritePageTitle) {
-        count.h1 = count.h1 + 1;
-        count.h2 = 0;
-        count.h3 = 0;
         level = count.h1 + ". ";
         rewrite = level + title;
     }
@@ -124,9 +126,10 @@ function handlerH2Toc(option, count, header, tocs) {
     }
     var h1Index = tocs.length - 1;
     var h1Toc = tocs[h1Index];
+    count.h2 = count.h2 + 1;
+    count.h3 = 0;
+    id = (count.h1 + '-' + count.h2 + "-") + id;
     if (option.isRewritePageTitle) {
-        count.h2 = count.h2 + 1;
-        count.h3 = 0;
         level = (count.h1 + '.' + count.h2 + ". ");
         rewrite = level + title;
     }
@@ -161,8 +164,9 @@ function handlerH3Toc(option, count, header, tocs) {
         return;
     }
     var h2Toc = h1Toc.children[h2Tocs.length - 1];
+    count.h3 = count.h3 + 1;
+    id = (count.h1 + "-" + count.h2 + "-" + count.h3 + "-") + id;
     if (option.isRewritePageTitle) {
-        count.h3 = count.h3 + 1;
         level = (count.h1 + "." + count.h2 + "." + count.h3 + ". ");
         rewrite = level + title;
     }


### PR DESCRIPTION
下述文字表示锚链接的id，不是标题，不会对标题做任何改动
修改前：
```
## 获取实例

## 成绩统计
### 方法
### 功能
### 参数
### 返回值

## 历年成绩
### 方法
### 功能
### 参数
### 返回值
```
此时第一个**返回值**与第二**返回值**的锚链接一样都是**返回值**，如果点第二个页面会定位到第一个

修改后：
```
## 1-1-获取实例

## 1-2-成绩统计
### 1-2-1-方法
### 1-2-2-功能
### 1-2-3-参数
### 1-2-4-返回值

## 1-3-历年成绩
### 1-3-1-方法
### 1-3-2-功能
### 1-3-3-参数
### 1-3-4-返回值
```
修改后两个**返回值**的锚链接不一样，可以准确定位