### PR TITLE
配置标题是否显示编号

### DIFF
--- a/assets/lib/config.js
+++ b/assets/lib/config.js
@@ -5,6 +5,12 @@ const defaultConfig = {
     showLevel: true,
     // 页面内的序号是否与 summary.md 中官方默认主题生成的序号相关联
     associatedWithSummary: true,
+    //显示level 
+    "level": {
+        "h1": true,
+        "h2": true,
+        "h3": true
+    },
     // 模式：分为三种：float：浮动导航、pageTop：页面内部顶部导航、null:不显示导航
     mode: "float",
     float: { //浮动导航设置
@@ -61,7 +67,7 @@ function handlerAll(bookIns) {
 }
 /**
  * 本类中 config 单例共享
- * @type {{config: {showLevel: boolean, associatedWithSummary: boolean, mode: string, float: {showLevelIcon: boolean, level1Icon: string, level2Icon: string, level3Icon: string}, top: {showLevelIcon: boolean, level1Icon: string, level2Icon: string, level3Icon: string}, themeDefault: {showLevel: boolean}}, handler: handler, handlerAll: handlerAll}}
+ * @type {{config: {showLevel: boolean, associatedWithSummary: boolean,level: {h1: boolean,h2: boolean, h3: boolean}, mode: string, float: {showLevelIcon: boolean, level1Icon: string, level2Icon: string, level3Icon: string}, top: {showLevelIcon: boolean, level1Icon: string, level2Icon: string, level3Icon: string}, themeDefault: {showLevel: boolean}}, handler: handler, handlerAll: handlerAll}}
  */
 module.exports = {
     config: defaultConfig,

--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -16,7 +16,9 @@ function handlerTocs($, page) {
     var count = {
         h1: 0,
         h2: 0,
-        h3: 0
+        h3: 0,
+        level1: '',//当前 H1 显示的层级
+        level2: '',//当前 H2 显示的层级
     };
     var titleCountMap = {}; // 用来记录标题出现的次数
     var h1 = 0, h2 = 0, h3 = 0;
@@ -53,7 +55,6 @@ function handlerTocs($, page) {
 function addId(header, titleCountMap) {
     var id = header.attr('id') || slug(header.text());
     var titleCount = titleCountMap[id] || 0;
-    console.log('id:', id, 'n:', titleCount, 'hashmap:', titleCountMap)
     titleCountMap[id] = titleCount + 1;
     if (titleCount) {//此标题已经存在  null/undefined/0/NaN/ 表达式时，统统被解释为false
         id = id + '_' + titleCount;
@@ -83,24 +84,25 @@ function titleAddAnchor(header, id) {
 function handlerH1Toc(config, count, header, tocs, pageLevel) {
     var title = header.text();
     var id = header.attr('id');
-    var level = ''; //层级
 
-    if (config.showLevel) {
-        //层级显示仅在需要的时候处理 
+    count.h2 = 0;
+    count.h3 = 0;
+
+    if (config.showLevel && config.level.h1) {
         count.h1 += 1;
-        count.h2 = 0;
-        count.h3 = 0;
-        level = count.h1 + '. ';
+        //层级显示仅在需要的时候处理 
         // 是否与官网默认主题层级序号相关联
         if (config.associatedWithSummary && config.themeDefault.showLevel) {
-            level = pageLevel + '.' + level;
+            count.level1 = pageLevel + '.' + count.h1 + '. ';
+        } else {
+            count.level1 = count.h1 + '. ';
         }
-        header.text(level + title); //重写标题
+        header.text(count.level1 + title); //重写标题
     }
     titleAddAnchor(header, id);
     tocs.push({
         name: title,
-        level: level,
+        level: count.level1,
         url: id,
         children: []
     });
@@ -113,7 +115,6 @@ function handlerH1Toc(config, count, header, tocs, pageLevel) {
 function handlerH2Toc(config, count, header, tocs, pageLevel) {
     var title = header.text();
     var id = header.attr('id');
-    var level = ''; //层级
 
     if (tocs.length <= 0) {
         titleAddAnchor(header, id);
@@ -122,19 +123,16 @@ function handlerH2Toc(config, count, header, tocs, pageLevel) {
 
     var h1Index = tocs.length - 1;
     var h1Toc = tocs[h1Index];
-    if (config.showLevel) {
+    count.h3 = 0;
+    if (config.showLevel && config.level.h2) {
         count.h2 += 1;
-        count.h3 = 0;
-        level = (count.h1 + '.' + count.h2 + '. ');
-        if (config.associatedWithSummary && config.themeDefault.showLevel) {
-            level = pageLevel + '.' + level;
-        }
-        header.text(level + title); //重写标题
+        count.level2 = count.level1.trim() + count.h2 + '. ';
+        header.text(count.level2 + title); //重写标题
     }
     titleAddAnchor(header, id);
     h1Toc.children.push({
         name: title,
-        level: level,
+        level: count.level2,
         url: id,
         children: []
     });
@@ -162,12 +160,9 @@ function handlerH3Toc(config, count, header, tocs, pageLevel) {
     }
     var h2Toc = h1Toc.children[h2Tocs.length - 1];
 
-    if (config.showLevel) {
+    if (config.showLevel && config.level.h3) {
         count.h3 += 1;
-        level = (count.h1 + '.' + count.h2 + '.' + count.h3 + '. ');
-        if (config.associatedWithSummary && config.themeDefault.showLevel) {
-            level = pageLevel + "." + level;
-        }
+        level = count.level2.trim() + count.h3 + '. ';
         header.text(level + title); //重写标题
     }
     titleAddAnchor(header, id);
@@ -279,7 +274,7 @@ function start(bookIns, page) {
         page.content = $.html();
         return;
     }
-    if(!/<!--[ \t]*ex_nonav[ \t]*-->/.test(page.content)){
+    if (!/<!--[ \t]*ex_nonav[ \t]*-->/.test(page.content)) {
         var config = Config.config;
         var mode = config.mode;
         if (mode == 'float') {

--- a/doc/config-en.md
+++ b/doc/config-en.md
@@ -2,25 +2,25 @@
 Configuration of this plug-in supports the following parameters:
 ```json
 {
-    showLevel: true,
-    associatedWithSummary: true,
-    level: {
-        h1: true,
-        h2: true,
-        h3: true
+    "showLevel": true,
+    "associatedWithSummary": true,
+    "level": {
+        "h1": true,
+        "h2": true,
+        "h3": true
     },
-    mode: "float",
-    float: {
-        showLevelIcon: false,
-        level1Icon: "fa fa-hand-o-right",
-        level2Icon: "fa fa-hand-o-right",
-        level3Icon: "fa fa-hand-o-right"
+    "mode": "float",
+    "float": {
+        "showLevelIcon": false,
+        "level1Icon": "fa fa-hand-o-right",
+        "level2Icon": "fa fa-hand-o-right",
+        "level3Icon": "fa fa-hand-o-right"
     },
-    pageTop: {
-        showLevelIcon: false,
-        level1Icon: "fa fa-hand-o-right",
-        level2Icon: "fa fa-hand-o-right",
-        level3Icon: "fa fa-hand-o-right"
+    "pageTop": {
+        "showLevelIcon": false,
+        "level1Icon": "fa fa-hand-o-right",
+        "level2Icon": "fa fa-hand-o-right",
+        "level3Icon": "fa fa-hand-o-right"
     }
 }
 ```

--- a/doc/config-en.md
+++ b/doc/config-en.md
@@ -4,6 +4,11 @@ Configuration of this plug-in supports the following parameters:
 {
     showLevel: true,
     associatedWithSummary: true,
+    level: {
+        h1: true,
+        h2: true,
+        h3: true
+    },
     mode: "float",
     float: {
         showLevelIcon: false,

--- a/doc/config.md
+++ b/doc/config.md
@@ -2,25 +2,25 @@
 本插件支持以下参数的配置：
 ```json
 {
-    showLevel: true,
-    associatedWithSummary: true,
-    level: {
-        h1: true,
-        h2: true,
-        h3: true
+    "showLevel": true,
+    "associatedWithSummary": true,
+    "level": {
+        "h1": true,
+        "h2": true,
+        "h3": true
     },
-    mode: "float",    
-    float: {
-        showLevelIcon: false,
-        level1Icon: "fa fa-hand-o-right",
-        level2Icon: "fa fa-hand-o-right",
-        level3Icon: "fa fa-hand-o-right"
+    "mode": "float",
+    "float": {
+        "showLevelIcon": false,
+        "level1Icon": "fa fa-hand-o-right",
+        "level2Icon": "fa fa-hand-o-right",
+        "level3Icon": "fa fa-hand-o-right"
     },
-    pageTop: {
-        showLevelIcon: false,
-        level1Icon: "fa fa-hand-o-right",
-        level2Icon: "fa fa-hand-o-right",
-        level3Icon: "fa fa-hand-o-right"
+    "pageTop": {
+        "showLevelIcon": false,
+        "level1Icon": "fa fa-hand-o-right",
+        "level2Icon": "fa fa-hand-o-right",
+        "level3Icon": "fa fa-hand-o-right"
     }
 }
 ```

--- a/doc/config.md
+++ b/doc/config.md
@@ -4,7 +4,12 @@
 {
     showLevel: true,
     associatedWithSummary: true,
-    mode: "float",
+    level: {
+        h1: true,
+        h2: true,
+        h3: true
+    },
+    mode: "float",    
     float: {
         showLevelIcon: false,
         level1Icon: "fa fa-hand-o-right",


### PR DESCRIPTION
#20 
增加三个配置项，配置指定级别标号是否显示，同时先前兼容

```json
{    
   "level": {
        "h1": true,
        "h2": true,
        "h3": true
    }
}
```

如： 可以 配置 `h1:false`关闭一级标题编号显示
