### PR TITLE
支持md文档H1,H2,H3层级不规则

### DIFF
--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -127,8 +127,13 @@ function handlerH2Toc(config, count, header, tocs, pageLevel, modifyHeader) {
     var level = ''; //层级
 
     if (tocs.length <= 0) {
-        titleAddAnchor(header, id);
-        return;
+        //一级节点为空时，生成一个空的一级节点，让二级节点附带在这个上面
+        tocs.push({
+            name: "",
+            level: "",
+            url: "",
+            children: []
+        });
     }
 
     var h1Index = tocs.length - 1;
@@ -169,15 +174,25 @@ function handlerH3Toc(config, count, header, tocs, pageLevel, modifyHeader) {
     var level = ''; //层级
 
     if (tocs.length <= 0) {
-        titleAddAnchor(header, id);
-        return;
+        //一级节点为空时，生成一个空的一级节点，让二级节点附带在这个上面
+        tocs.push({
+            name: "",
+            level: "",
+            url: "",
+            children: []
+        });
     }
     var h1Index = tocs.length - 1;
     var h1Toc = tocs[h1Index];
     var h2Tocs = h1Toc.children;
     if (h2Tocs.length <= 0) {
-        titleAddAnchor(header, id);
-        return;
+        //二级节点为空时，生成一个空的二级节点，让三级节点附带在这个上面
+        h2Tocs.push({
+            name: "",
+            level: "",
+            url: "",
+            children: []
+        });
     }
     var h2Toc = h1Toc.children[h2Tocs.length - 1];
 
@@ -226,12 +241,16 @@ function handlerFloatNavbar($, tocs) {
     var html = "<div id='anchor-navigation-ex-navbar'><i class='" + floatIcon + "'></i><ul>";
     for (var i = 0; i < tocs.length; i++) {
         var h1Toc = tocs[i];
-        html += "<li><span class='title-icon " + level1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + h1Toc.level + "</b>" + h1Toc.name + "</a></li>";
+        if (h1Toc.name){
+            html += "<li><span class='title-icon " + level1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + h1Toc.level + "</b>" + h1Toc.name + "</a></li>";
+        }
         if (h1Toc.children.length > 0) {
             html += "<ul>"
             for (var j = 0; j < h1Toc.children.length; j++) {
                 var h2Toc = h1Toc.children[j];
-                html += "<li><span class='title-icon " + level2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + h2Toc.level + "</b>" + h2Toc.name + "</a></li>";
+                if(h2Toc.name){
+                    html += "<li><span class='title-icon " + level2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + h2Toc.level + "</b>" + h2Toc.name + "</a></li>";
+                }
                 if (h2Toc.children.length > 0) {
                     html += "<ul>";
                     for (var k = 0; k < h2Toc.children.length; k++) {
@@ -267,12 +286,16 @@ function buildTopNavbar($, tocs) {
     var html = "<div id='anchor-navigation-ex-pagetop-navbar'><ul>";
     for (var i = 0; i < tocs.length; i++) {
         var h1Toc = tocs[i];
-        html += "<li><span class='title-icon " + level1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + h1Toc.level + "</b>" + h1Toc.name + "</a></li>";
+        if(h1Toc.name){
+            html += "<li><span class='title-icon " + level1Icon + "'></span><a href='#" + h1Toc.url + "'><b>" + h1Toc.level + "</b>" + h1Toc.name + "</a></li>";
+        }
         if (h1Toc.children.length > 0) {
             html += "<ul>"
             for (var j = 0; j < h1Toc.children.length; j++) {
                 var h2Toc = h1Toc.children[j];
-                html += "<li><span class='title-icon " + level2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + h2Toc.level + "</b>" + h2Toc.name + "</a></li>";
+                if(h2Toc.name){
+                    html += "<li><span class='title-icon " + level2Icon + "'></span><a href='#" + h2Toc.url + "'><b>" + h2Toc.level + "</b>" + h2Toc.name + "</a></li>";
+                }
                 if (h2Toc.children.length > 0) {
                     html += "<ul>";
                     for (var k = 0; k < h2Toc.children.length; k++) {


### PR DESCRIPTION
此前版本中，必须依赖md文档中的h1，h2，h3是规则的，即h2必须在h1下，h3必须在h2下，对于不规则的场景不予支持。
提交的MR中支持到不规则场景，例如当遇到h2不在h1之下时，先生成一个空的h1节点，并将该h2放在这个空的h1节点下。在生成html的时候，忽略掉空节点